### PR TITLE
fix(build): 未传lowcodeDir字段

### DIFF
--- a/index.js
+++ b/index.js
@@ -279,6 +279,7 @@ async function build(options, pluginOptions, execCompile) {
       metaFormat,
       components,
       engineScope === '@alilc' ? 'npm' : 'tnpm',
+      lowcodeDir,
       entryPath,
     ));
   const confirmedMetaTypes = confirmMetaTypes(rootDir, lowcodeDir, metaTypes);


### PR DESCRIPTION
initLowCodeSchema方法调用时少传了lowcodeDir字段，导致pluginOptions传入lowcodeDir和entryPath无效